### PR TITLE
Added support for multiple reporters to the `makeReport` task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+  'use strict';
 
   var dateFormat = require('dateformat');
 

--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -1,4 +1,6 @@
 exports.init = function(grunt) {
+  'use strict';
+
   var fs = require('fs');
   var path = require('path');
 
@@ -65,8 +67,20 @@ exports.init = function(grunt) {
         list.forEach(function(json) {
           collector.add(JSON.parse(json));
         });
-        var reporter = istanbul.Report.create(options.type, options);
-        reporter.writeReport(collector, true);
+        var reporters = options.reporters &&
+          typeof options.reporters === 'object' ? options.reporters : {};
+        var reporterTypes = Object.keys(reporters);
+        if (!reporterTypes.length) {
+          reporterTypes.push(options.type);
+          reporters = {};
+          reporters[options.type] = options;
+        }
+        reporterTypes.forEach(function(type) {
+          if (reporters[type]) {
+            var reporter = istanbul.Report.create(type, reporters[type]);
+            reporter.writeReport(collector, true);
+          }
+        });
         this.next();
       }, function() {
         flowEnd(this.err, done);

--- a/tasks/istanbul.js
+++ b/tasks/istanbul.js
@@ -54,6 +54,7 @@ module.exports = function(grunt) {
     this.requiresConfig(key);
     var files = grunt.config(key);
     var options = this.options({
+      reporters : {},
       type : 'lcov',
       dir : 'build/reports/'
     });


### PR DESCRIPTION
Hello!

I've added another option to the `makeReport` task: `reporters`. It takes the following form:

```
options: {
  reporters: {
    '<reporter-type>': <reporter-options>
  }
}
```

where:
- `<reporter-type>` is a reporter type supported by Istanbul (lcov, text, text-summary...)
- `<reporter-options>` is an options object for the specified reporter type or a truthy value if that reporter does not have any options or a falsy value if that reporter should be skipped.

If the `options.reporters` option is not specified, it will be created from `options` for backwards compatibility:

``` js
reporters[options.type] = options;
```

For example, to recreate a result of `istanbul cover --report lcov --print both ...` one can configure the gruntfile like this:

``` js
    makeReport: {
      src: lcovReportDir + '/*.json',
      options : {
        reporters: {
          'lcov': {dir: lcovReportDir},
          'text': true,
          'text-summary': true
        }
      }
    }
```

In action: https://travis-ci.org/morkai/h5.step/builds/4705195 (scroll down to **Running "makeReport" task**)
