### PR TITLE
Fix "lazy: true" option sometimes not calling flowEnd

### DIFF
--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -98,6 +98,8 @@ exports.init = function(grunt) {
         }, function end(f) {
           if (f.instrument) {
             this.exec(instFlow, { name : f.name }, this.async());
+          } else {
+            flowEnd(this.err, this.next.bind(this));
           }
         });
 


### PR DESCRIPTION
If the new lazy: true option is currently used, flowEnd is not called for
any files in which no changes have been detected.  Fixing this ensures
that the output from Istanbul is always the same (whether or not lazy
is set, and regardless of the amount of edited files), and ensures that
Grunt jobs aren't terminated early because this.next.bind(this) isn't
called the expected number of times.

(Also tweaked some indentation)
