### PR TITLE
Allow arrays of coverage types to be generated

### DIFF
--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -35,7 +35,14 @@ exports.init = function(grunt) {
       }
     };
 
-    append(options.type);
+    if (options.type instanceof Array) {
+      options.type.forEach(function(n) {
+        append(n);
+      })
+    }
+    else {
+      append(options.type);
+    }
 
     var mapping = {
       'none' : [],


### PR DESCRIPTION
This change allows you to specify that multiple types of coverage reports should be generated.  In our case, we'd like one for our Jenkins build and a different more human-readable one for local builds.

Doing it this way preserves backwards compatibility with the previous style of specifying only one report type.
