### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,23 +40,28 @@
   },
   "dependencies": {
     "chalk": "1.1.1",
-    "istanbul" : "0.4.2",
+    "istanbul": "0.4.2",
     "nue": "0.7.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.12.0",
     "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt-contrib-clean" : "~0.7.0",
+    "grunt-contrib-clean": "~0.7.0",
     "isparta": "^2.2.0",
     "mkdirp": "~0.5.1",
     "rimraf": "~2.5.1",
-    "dateformat" : "~1.0.12"
+    "dateformat": "~1.0.12"
   },
   "keywords": [
-    "gruntplugin","coverage","code coverage", "JS code coverage", "JS coverage","istanbul"
+    "gruntplugin",
+    "coverage",
+    "code coverage",
+    "JS code coverage",
+    "JS coverage",
+    "istanbul"
   ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
