### PR TITLE
Avoid duplicate paths in coverage.json on Windows when using include-all-sources

### DIFF
--- a/tasks/istanbul.js
+++ b/tasks/istanbul.js
@@ -8,6 +8,7 @@
 module.exports = function(grunt) {
   'use strict';
 
+  var path = require('path');
   var helper = require('./helpers').init(grunt);
   grunt
       .registerTask('instrument', 'instruments a file or a directory tree',
@@ -22,9 +23,9 @@ module.exports = function(grunt) {
 
             var expandOptions = options.cwd ? {cwd: options.cwd} : {};
 
-             var allFiles = grunt.file.expand(expandOptions, files);
-             global['allFiles'] = allFiles;
-             helper.instrument(allFiles, options, this.async());
+            var allFiles = grunt.file.expand(expandOptions, files).map(path.normalize);
+            global['allFiles'] = allFiles;
+            helper.instrument(allFiles, options, this.async());
           });
 
   grunt.registerTask('reloadTasks', 'override instrumented tasks', function(


### PR DESCRIPTION
Currently on Windows two different paths are stored on the coverage object when using include-all-sources. The coverage data from the test run is stored using the normalized path, since it is put through path.join. The coverage data from addUncoveredFiles uses the unnormalized paths returned by grunt.file.expand.

This means on Windows every instrumented file that is executed by a test has an extra entry in the coverage file from addUncoveredFiles.

Normalizing the paths at the very start seems like an easy way to make everything consistent.