### PR TITLE
Added multi-task support to instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,12 @@ module.exports = function (grunt) {
   });
 ```
 ```bash
-> grunt coverage
-> grunt coverage:api
-> grunt coverage:web
+# coverage with api and web insturmentation
+$ grunt coverage
+# coverage with api insturmentation
+$ grunt coverage:api
+# coverage with web insturmentation
+$ grunt coverage:web
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.grunt.registerTask('coverage', function(arg) {
+  grunt.registerTask('coverage', function(arg) {
     var insturment = arg ? 'insturment:' + arg : 'insturment';
     
     grunt.task.run(['env:coverage', instrument, 'mochaTest',

--- a/README.md
+++ b/README.md
@@ -126,6 +126,66 @@ module.exports = function (grunt) {
 };
 
 ```
+If you wan to insturment multiple locations, you specify multiple task targets:
+
+```javascript
+// in Gruntfile.js
+module.exports = function (grunt) {
+
+  grunt.initConfig({
+    env: {
+      coverage: {
+        APP_DIR_FOR_CODE_COVERAGE: '../test/coverage/instrument/app/'
+      }
+    },
+    instrument: {
+      api: {
+        files: 'app/*.js',
+        options: {
+          basePath: 'test/coverage/instrument/'
+        }
+      },
+      web: {
+        files: 'web/*.js',
+        options: {
+          basePath: 'test/coverage/instrument/'
+        }
+      }
+    },
+    mochaTest: {
+      options: {
+        reporter: 'spec'
+      },
+      src: ['test/*.js']
+    },
+    storeCoverage: {
+      options: {
+        dir: 'test/coverage/reports'
+      }
+    },
+    makeReport: {
+      src: 'test/coverage/reports/**/*.json',
+      options: {
+        type: 'lcov',
+        dir: 'test/coverage/reports',
+        print: 'detail'
+      }
+    }
+  });
+
+  grunt.grunt.registerTask('coverage', function(arg) {
+    var insturment = arg ? 'insturment:' + arg : 'insturment';
+    
+    grunt.task.run(['env:coverage', instrument, 'mochaTest',
+      'storeCoverage', 'makeReport']);
+  });
+```
+```bash
+> grunt coverage
+> grunt coverage:api
+> grunt coverage:web
+```
+
 
 By default only files that have coverage are stored. When the 'include-all-sources' option is set to true it will show all instrumented files even if their coverage percentage is 0. To see all instrumented files you can init the `storeCoverage` task as follows:
 ```javascript

--- a/tasks/istanbul.js
+++ b/tasks/istanbul.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
     });
 
   grunt.registerTask('reloadTasks', 'override instrumented tasks', function(
-    target) {
+      target) {
     var key = 'reloadTasks.rootPath';
     this.requiresConfig(key);
     var path = grunt.config(key);
@@ -46,14 +46,15 @@ module.exports = function(grunt) {
     grunt.log.ok();
   });
 
-  grunt.registerTask('storeCoverage', 'store coverage from global', function() {
+  grunt.registerTask('storeCoverage', 'store coverage from global', function(
+      target) {
     var options = this.options({
-      dir: 'build/reports/',
-      json: 'coverage.json',
-      coverageVar: '__coverage__'
+      dir : 'build/reports/',
+      json : 'coverage.json',
+      coverageVar : '__coverage__'
     });
     if (global[options.coverageVar]) {
-      if (options['include-all-sources']) {
+      if (options["include-all-sources"]) {
         helper.addUncoveredFiles(global[options.coverageVar], options, global['allFiles']);
       }
       helper.storeCoverage(global[options.coverageVar], options, this.async());
@@ -67,10 +68,10 @@ module.exports = function(grunt) {
     this.requiresConfig(key);
     var files = grunt.config(key);
     var options = this.options({
-      reporters: {},
-      type: 'lcov',
-      dir: 'build/reports/',
-      print: 'none'
+      reporters : {},
+      type : 'lcov',
+      dir : 'build/reports/',
+      print : 'none'
     });
     helper.makeReport(grunt.file.expand(files), options, this.async());
   });

--- a/tasks/istanbul.js
+++ b/tasks/istanbul.js
@@ -26,9 +26,7 @@ module.exports = function(grunt) {
         return;
       }
 
-      var expandOptions = options.cwd ? {
-        cwd: options.cwd
-      } : {};
+      var expandOptions = options.cwd ? {cwd: options.cwd} : {};
 
       var allFiles = grunt.file.expand(expandOptions, files).map(path.normalize);
       global['allFiles'] = (global['allFiles'] || []).concat(allFiles);

--- a/tasks/istanbul.js
+++ b/tasks/istanbul.js
@@ -6,65 +6,72 @@
  * Licensed under the MIT license.
  */
 module.exports = function(grunt) {
-  'use strict';
+    'use strict';
 
-  var path = require('path');
-  var helper = require('./helpers').init(grunt);
-  grunt
-      .registerTask('instrument', 'instruments a file or a directory tree',
-          function(target) {
-            var key = 'instrument.files';
-            this.requiresConfig(key);
-            var files = grunt.config(key);
+    var path = require('path');
+    var helper = require('./helpers').init(grunt);
+
+    grunt.registerMultiTask('instrument', 'instruments a file or a directory tree',
+        function() {
             var options = this.options({
-              basePath : 'build/instrument/',
-              flatten : false
+                basePath: 'build/instrument/',
+                flatten: false
             });
 
-            var expandOptions = options.cwd ? {cwd: options.cwd} : {};
+            var files = this.data.files || this.filesSrc;
+
+            if (files.length === 0) {
+                grunt.log.write('No files to instrument...');
+                grunt.log.ok();
+                return;
+            }
+
+            var expandOptions = options.cwd ? {
+                cwd: options.cwd
+            } : {};
 
             var allFiles = grunt.file.expand(expandOptions, files).map(path.normalize);
-            global['allFiles'] = allFiles;
+            global['allFiles'] = (global['allFiles'] || []).concat(allFiles);
+
             helper.instrument(allFiles, options, this.async());
-          });
+        });
 
-  grunt.registerTask('reloadTasks', 'override instrumented tasks', function(
-      target) {
-    var key = 'reloadTasks.rootPath';
-    this.requiresConfig(key);
-    var path = grunt.config(key);
-    grunt.verbose.writeln('Tasks from ' + path);
-    grunt.loadTasks(path);
-    grunt.log.ok();
-  });
-
-  grunt.registerTask('storeCoverage', 'store coverage from global', function(
-      target) {
-    var options = this.options({
-      dir : 'build/reports/',
-      json : 'coverage.json',
-      coverageVar : '__coverage__'
+    grunt.registerTask('reloadTasks', 'override instrumented tasks', function(
+        target) {
+        var key = 'reloadTasks.rootPath';
+        this.requiresConfig(key);
+        var path = grunt.config(key);
+        grunt.verbose.writeln('Tasks from ' + path);
+        grunt.loadTasks(path);
+        grunt.log.ok();
     });
-    if (global[options.coverageVar]) {
-      if (options["include-all-sources"]) {
-        helper.addUncoveredFiles(global[options.coverageVar], options, global['allFiles']);
-      }
-      helper.storeCoverage(global[options.coverageVar], options, this.async());
-    } else {
-      grunt.fail.fatal('No coverage information was collected');
-    }
-  });
 
-  grunt.registerTask('makeReport', 'make coverage report', function(target) {
-    var key = 'makeReport.src';
-    this.requiresConfig(key);
-    var files = grunt.config(key);
-    var options = this.options({
-      reporters : {},
-      type : 'lcov',
-      dir : 'build/reports/',
-      print : 'none'
+    grunt.registerTask('storeCoverage', 'store coverage from global', function() {
+        var options = this.options({
+            dir: 'build/reports/',
+            json: 'coverage.json',
+            coverageVar: '__coverage__'
+        });
+        if (global[options.coverageVar]) {
+            if (options['include-all-sources']) {
+                helper.addUncoveredFiles(global[options.coverageVar], options, global['allFiles']);
+            }
+            helper.storeCoverage(global[options.coverageVar], options, this.async());
+        } else {
+            grunt.fail.fatal('No coverage information was collected');
+        }
     });
-    helper.makeReport(grunt.file.expand(files), options, this.async());
-  });
+
+    grunt.registerTask('makeReport', 'make coverage report', function(target) {
+        var key = 'makeReport.src';
+        this.requiresConfig(key);
+        var files = grunt.config(key);
+        var options = this.options({
+            reporters: {},
+            type: 'lcov',
+            dir: 'build/reports/',
+            print: 'none'
+        });
+        helper.makeReport(grunt.file.expand(files), options, this.async());
+    });
 };

--- a/tasks/istanbul.js
+++ b/tasks/istanbul.js
@@ -6,72 +6,72 @@
  * Licensed under the MIT license.
  */
 module.exports = function(grunt) {
-    'use strict';
+  'use strict';
 
-    var path = require('path');
-    var helper = require('./helpers').init(grunt);
+  var path = require('path');
+  var helper = require('./helpers').init(grunt);
 
-    grunt.registerMultiTask('instrument', 'instruments a file or a directory tree',
-        function() {
-            var options = this.options({
-                basePath: 'build/instrument/',
-                flatten: false
-            });
+  grunt.registerMultiTask('instrument', 'instruments a file or a directory tree',
+    function() {
+      var options = this.options({
+        basePath: 'build/instrument/',
+        flatten: false
+      });
 
-            var files = this.data.files || this.filesSrc;
+      var files = this.data.files || this.filesSrc;
 
-            if (files.length === 0) {
-                grunt.log.write('No files to instrument...');
-                grunt.log.ok();
-                return;
-            }
-
-            var expandOptions = options.cwd ? {
-                cwd: options.cwd
-            } : {};
-
-            var allFiles = grunt.file.expand(expandOptions, files).map(path.normalize);
-            global['allFiles'] = (global['allFiles'] || []).concat(allFiles);
-
-            helper.instrument(allFiles, options, this.async());
-        });
-
-    grunt.registerTask('reloadTasks', 'override instrumented tasks', function(
-        target) {
-        var key = 'reloadTasks.rootPath';
-        this.requiresConfig(key);
-        var path = grunt.config(key);
-        grunt.verbose.writeln('Tasks from ' + path);
-        grunt.loadTasks(path);
+      if (files.length === 0) {
+        grunt.log.write('No files to instrument...');
         grunt.log.ok();
+        return;
+      }
+
+      var expandOptions = options.cwd ? {
+        cwd: options.cwd
+      } : {};
+
+      var allFiles = grunt.file.expand(expandOptions, files).map(path.normalize);
+      global['allFiles'] = (global['allFiles'] || []).concat(allFiles);
+
+      helper.instrument(allFiles, options, this.async());
     });
 
-    grunt.registerTask('storeCoverage', 'store coverage from global', function() {
-        var options = this.options({
-            dir: 'build/reports/',
-            json: 'coverage.json',
-            coverageVar: '__coverage__'
-        });
-        if (global[options.coverageVar]) {
-            if (options['include-all-sources']) {
-                helper.addUncoveredFiles(global[options.coverageVar], options, global['allFiles']);
-            }
-            helper.storeCoverage(global[options.coverageVar], options, this.async());
-        } else {
-            grunt.fail.fatal('No coverage information was collected');
-        }
-    });
+  grunt.registerTask('reloadTasks', 'override instrumented tasks', function(
+    target) {
+    var key = 'reloadTasks.rootPath';
+    this.requiresConfig(key);
+    var path = grunt.config(key);
+    grunt.verbose.writeln('Tasks from ' + path);
+    grunt.loadTasks(path);
+    grunt.log.ok();
+  });
 
-    grunt.registerTask('makeReport', 'make coverage report', function(target) {
-        var key = 'makeReport.src';
-        this.requiresConfig(key);
-        var files = grunt.config(key);
-        var options = this.options({
-            reporters: {},
-            type: 'lcov',
-            dir: 'build/reports/',
-            print: 'none'
-        });
-        helper.makeReport(grunt.file.expand(files), options, this.async());
+  grunt.registerTask('storeCoverage', 'store coverage from global', function() {
+    var options = this.options({
+      dir: 'build/reports/',
+      json: 'coverage.json',
+      coverageVar: '__coverage__'
     });
+    if (global[options.coverageVar]) {
+      if (options['include-all-sources']) {
+        helper.addUncoveredFiles(global[options.coverageVar], options, global['allFiles']);
+      }
+      helper.storeCoverage(global[options.coverageVar], options, this.async());
+    } else {
+      grunt.fail.fatal('No coverage information was collected');
+    }
+  });
+
+  grunt.registerTask('makeReport', 'make coverage report', function(target) {
+    var key = 'makeReport.src';
+    this.requiresConfig(key);
+    var files = grunt.config(key);
+    var options = this.options({
+      reporters: {},
+      type: 'lcov',
+      dir: 'build/reports/',
+      print: 'none'
+    });
+    helper.makeReport(grunt.file.expand(files), options, this.async());
+  });
 };


### PR DESCRIPTION
These changes allow multi target grunt configurations to be used in instrumentation tasks which allows a user to instrument multiple locations or specify that a subset of locations be instrumented in a given task run.